### PR TITLE
Applying of Morpher generator for .xlsx files added.

### DIFF
--- a/EasyDox.Tests/EasyDox.Tests.csproj
+++ b/EasyDox.Tests/EasyDox.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="DocxTests.cs" />
     <Compile Include="EngineEvalTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="XlsxTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyDox\EasyDox.csproj">
@@ -69,6 +70,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="DocxComplexField2.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="XlsxSharedStrings.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="XlsxSharedStrings2.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/EasyDox.Tests/XlsxSharedStrings.xml
+++ b/EasyDox.Tests/XlsxSharedStrings.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="4" uniqueCount="4"><si><t>[[Родительный (Должность представителя Лицензиата) ]]</t></si><si><t xml:space="preserve">[[ Родительный (ФИО представителя Лицензиата) ]] </t></si><si><t>[[Полное наименование компании Лицензиата]]</t></si><si><t xml:space="preserve">  На основании доверенности № [[Доверенность]] в лице [[ Фамилия ]], проживающий по адресу:[[ Адрес]] </t></si></sst>

--- a/EasyDox.Tests/XlsxSharedStrings2.xml
+++ b/EasyDox.Tests/XlsxSharedStrings2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="4" uniqueCount="4">
+<si>
+<t xml:space="preserve">  На основании доверенности № [[Доверенность]] в лице [[ Фамилия ]], проживающий по адресу: [[ Адрес]] </t>
+</si>
+</sst>

--- a/EasyDox.Tests/XlsxTests.cs
+++ b/EasyDox.Tests/XlsxTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Xml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EasyDox.Tests
+{
+    [TestClass]
+    public class XlsxTests
+    {
+        [TestMethod]
+        public void XlsxRegexMethod1()
+        {
+            var match = Xlsx.regex.Match("[[Должность]]");
+            Assert.IsTrue(match.Success);
+            Assert.AreEqual("Должность", match.Groups["name"].Value);
+            Assert.AreEqual("[[Должность]]", match.Groups["template"].Value);
+        }
+
+        [TestMethod]
+        public void XlsxRegexMethod2()
+        {
+            var match = Xlsx.regex.Match(" [[ Должность ]] ");
+            Assert.IsTrue(match.Success);
+            Assert.AreEqual("Должность", match.Groups["name"].Value);
+            Assert.AreEqual("[[ Должность ]]", match.Groups["template"].Value);
+        }
+
+        [TestMethod]
+        public void XlsxRegexMethod3()
+        {
+            var match = Xlsx.regex.Match("ООО \"Самая лучшая компания\", [[Адрес]] ");
+            
+            Assert.IsTrue(match.Success);
+            Assert.AreEqual("Адрес", match.Groups["name"].Value);
+            Assert.AreEqual("[[Адрес]]", match.Groups["template"].Value);
+        }
+
+        [TestMethod]
+        public void XlsxRegexMethod6()
+        {
+            var match = Xlsx.regex.Match("[[Доверенность]][[Фамилия]][[Отчество]]");
+            Assert.IsTrue(match.Success);
+
+            Assert.AreEqual(3, match.Groups["name"].Captures.Count);
+            Assert.AreEqual("Доверенность", match.Groups["name"].Captures[0].Value);
+            Assert.AreEqual("Фамилия", match.Groups["name"].Captures[1].Value);
+            Assert.AreEqual("Отчество", match.Groups["name"].Captures[2].Value);
+
+            Assert.AreEqual(3, match.Groups["template"].Captures.Count);
+            Assert.AreEqual("[[Доверенность]]", match.Groups["template"].Captures[0].Value);
+            Assert.AreEqual("[[Фамилия]]", match.Groups["template"].Captures[1].Value);
+            Assert.AreEqual("[[Отчество]]", match.Groups["template"].Captures[2].Value);
+
+        }
+
+        [TestMethod]
+        public void XlsxRegexMethod7()
+        {
+            var match = Xlsx.regex.Match(" На основании доверенности № [[Доверенность]] в лице [[ Фамилия ]], проживающий по адресу:[[ Адрес]] ");
+            Assert.IsTrue(match.Success);
+
+            Assert.AreEqual(3, match.Groups["name"].Captures.Count);
+            Assert.AreEqual("Доверенность", match.Groups["name"].Captures[0].Value);
+            Assert.AreEqual("Фамилия", match.Groups["name"].Captures[1].Value);
+            Assert.AreEqual("Адрес", match.Groups["name"].Captures[2].Value);
+
+            Assert.AreEqual(3, match.Groups["template"].Captures.Count);
+            Assert.AreEqual("[[Доверенность]]", match.Groups["template"].Captures[0].Value);
+            Assert.AreEqual("[[ Фамилия ]]", match.Groups["template"].Captures[1].Value);
+            Assert.AreEqual("[[ Адрес]]", match.Groups["template"].Captures[2].Value);
+
+        }
+
+        [TestMethod]
+        [DeploymentItem("XlsxSharedStrings.xml")]
+        public void XlsxParseSharedStrings()
+        {
+            var xdoc = new XmlDocument();
+            xdoc.Load("XlsxSharedStrings.xml");
+            var fields = Xlsx.GetFields(xdoc).ToArray();
+
+            Assert.AreEqual(4, fields.Length);
+
+            Assert.AreEqual("[[Родительный (Должность представителя Лицензиата) ]]", fields[0].Text);
+            Assert.AreEqual("[[ Родительный (ФИО представителя Лицензиата) ]] ", fields[1].Text);
+            Assert.AreEqual("[[Полное наименование компании Лицензиата]]", fields[2].Text);
+            Assert.AreEqual("  На основании доверенности № [[Доверенность]] в лице [[ Фамилия ]], проживающий по адресу:[[ Адрес]] ", fields[3].Text);
+        }
+
+        [TestMethod]
+        [DeploymentItem("XlsxSharedStrings2.xml")]
+        public void XlsxSubstitureSharedStrings()
+        {
+            var xdoc = new XmlDocument();
+            xdoc.Load("XlsxSharedStrings2.xml");
+
+            var stream = new MemoryStream();
+            xdoc.Save(stream);
+
+            var xdoc2 = new XmlDocument();
+            stream.Position = 0;
+            xdoc2.Load(stream);
+
+            var dict = new Dictionary<string, string>()
+            {
+                {"Доверенность", "123-456/АГ"},
+                {"Адрес",  "Петропавловск-Камчатский"},
+                {"Фамилия", "Иванов И.П."},
+            };
+
+            var engine = new Engine();
+            Xlsx.ReplaceMergeFieldsAndReturnMissingFieldNames(xdoc2, dict, engine);
+
+            var fields = Xlsx.GetFields(xdoc2);
+
+            Assert.AreEqual("  На основании доверенности № 123-456/АГ в лице Иванов И.П., проживающий по адресу: Петропавловск-Камчатский ", fields.Single().Value);
+        }
+
+    }
+}

--- a/EasyDox/Engine.cs
+++ b/EasyDox/Engine.cs
@@ -37,6 +37,12 @@ namespace EasyDox
             return Docx.MergeInplace(this, outputPath, fieldValues);
         }
 
+        public IEnumerable<IMergeError> MergeXL(string templatePath, Dictionary<string, string> fieldValues, string outputPath)
+        {
+            File.Copy(templatePath, outputPath, true);
+            return Xlsx.MergeInplace(this, outputPath, fieldValues);
+        }
+
         internal string Eval (string expression, Properties properties)
         {
             IExpression exp = Parse (expression);

--- a/EasyDox/Xlsx.cs
+++ b/EasyDox/Xlsx.cs
@@ -1,5 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
+using System.Xml;
+using System.Xml.XPath;
+using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace EasyDox
 {
@@ -18,7 +24,162 @@ namespace EasyDox
             string xlsxPath,
             Dictionary<string, string> fieldValues)
         {
-            throw new NotImplementedException();
+            using (var pkg = Package.Open(xlsxPath, FileMode.Open, FileAccess.ReadWrite))
+            {
+                // Specify the URI of the part to be read
+                PackagePart part = pkg.GetPart(new Uri ("/xl/sharedStrings.xml", UriKind.Relative));
+
+                // Get the document part from the package.
+                // Load the XML in the part into an XmlDocument instance.
+                var xdoc = new XmlDocument();
+                xdoc.Load(part.GetStream(FileMode.Open, FileAccess.Read));
+
+                var fields = ReplaceMergeFieldsAndReturnMissingFieldNames(xdoc, fieldValues, engine);
+
+                using (var partWrt = new StreamWriter(part.GetStream(FileMode.Open, FileAccess.Write)))
+                {
+                    xdoc.Save(partWrt);
+                }
+
+                return fields;
+            }
         }
+
+        class MergeError : IMergeError
+        {
+            private readonly Func<IMergeErrorVisitor, string> callback;
+
+            public MergeError(Func<IMergeErrorVisitor, string> callback)
+            {
+                this.callback = callback;
+            }
+
+            public string Accept(IMergeErrorVisitor visitor)
+            {
+                return callback(visitor);
+            }
+        }
+
+        public static IEnumerable<IMergeError> ReplaceMergeFieldsAndReturnMissingFieldNames(XmlDocument xdoc, Dictionary<string, string> dict, Engine engine)
+        {
+            var fields = GetFields(xdoc);
+
+            var errors = new List<IMergeError>();
+
+            var properties = new Properties(dict);
+
+            foreach (var field in fields)
+            {
+                var value = field.Text;
+                var matches = regex.Match(field.Text);
+
+                if (matches.Success)
+                {
+                    var fieldNames = matches.Groups["name"].Captures;
+                    var fieldTemplates = matches.Groups["template"].Captures;
+
+                    for(var fieldIdx = 0; fieldIdx < fieldNames.Count; ++fieldIdx )
+                    {
+                        var fieldName = fieldNames[fieldIdx].ToString();
+                        var fieldTemlate = fieldTemplates[fieldIdx].ToString();
+
+                        var exp = engine.Parse(fieldName.ToString());
+
+                        if (exp == null)
+                        {
+                            errors.Add(new MergeError(v => v.InvalidExpression(fieldName.ToString())));
+                        }
+                        else
+                        {
+                            var missingProperties = new List<string>();
+
+                            properties.FindMissingProperties(exp, missingProperties);
+
+                            errors.AddRange(missingProperties.Select(p => new MergeError(v => v.MissingField(p))));
+
+                            if (missingProperties.Count == 0) // otherwise Eval will throw
+                            {
+                                value = value.Replace(fieldTemlate, properties.Eval(exp));
+                            }
+                        }
+                    }
+
+                    field.Value = value;
+                }
+            }
+
+            return errors;
+        }
+
+        internal static IEnumerable<IField> GetFields(XmlDocument xdoc)
+        {
+            var nsManager = new XmlNamespaceManager(new NameTable());
+            nsManager.AddNamespace("s", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+
+            XPathNavigator xDocNavigator = xdoc.CreateNavigator();
+
+            var nodes = xDocNavigator.Select("//s:sst/s:si/s:t", nsManager);
+
+            foreach (XPathNavigator navigator in nodes)
+            {
+                yield return new SimpleField(navigator, nsManager);
+            }
+        }
+
+        internal static readonly Regex regex = new Regex(
+
+            @"^(.*?(?<template>\[\[[\s]*(((?<name>[^\s""]+?)|([""](?<name>[^""]+?)[""]))[\s]*)\]\]))+",
+
+            RegexOptions.Compiled
+            | RegexOptions.CultureInvariant
+            | RegexOptions.ExplicitCapture
+            | RegexOptions.IgnoreCase
+            | RegexOptions.IgnorePatternWhitespace
+            | RegexOptions.Singleline);
+
+        internal interface IField
+        {
+            string Text { get; }
+            string Value { get; set; }
+        }
+
+        internal class SimpleField : IField
+        {
+            private readonly XPathNavigator node;
+            private readonly XmlNamespaceManager namespaceManager;
+
+            public SimpleField(XPathNavigator node, XmlNamespaceManager namespaceManager)
+            {
+                this.node = node;
+                this.namespaceManager = namespaceManager;
+            }
+
+            string IField.Text
+            {
+                // ReSharper disable AssignNullToNotNullAttribute
+                get { return node.InnerXml; }
+                // ReSharper restore AssignNullToNotNullAttribute
+            }
+
+            string IField.Value
+            {
+                get
+                {
+                    return ValueNode.Value;
+                }
+                set
+                {
+                    ValueNode.SetValue(value);
+                }
+            }
+
+            private XPathNavigator ValueNode
+            {
+                //get { return node.Select("w:r/w:t", namespaceManager).Cast<XPathNavigator>().Single(); }
+                get { return node; }
+
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Applying of Morpher generator for .xlsx files added.
Double square brackets  are used to specify a Morpher template in Excel
cell.
Example: Some text [[morpher_tepmlate]] other text.